### PR TITLE
Add baseline workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,53 @@ PBENCH_SSH_PUBLIC_KEY_FILE
 PBENCH_SERVER
 ```
 
+## RHCOS Baseline Workload
+
+The RHCOS baseline workload playbook is `workloads/baseline.yml` and will run the baseline workload on your RHCOS cluster.
+
+Running from CLI:
+
+```sh
+$ cp workloads/inventory.example inventory
+$ # Add orchestration host to inventory
+$ # Edit vars in workloads/vars/baseline.yml or define Environment vars (See below)
+$ time ansible-playbook -vv -i inventory workloads/baseline.yml
+```
+
+### Environment variables for RHCOS baseline workload playbook
+
+```
+###############################################################################
+# Ansible SSH variables.
+###############################################################################
+PUBLIC_KEY
+PRIVATE_KEY
+
+ORCHESTRATION_USER
+###############################################################################
+# RHCOS workload variables.
+###############################################################################
+WORKLOAD_IMAGE
+
+WORKLOAD_JOB_NODE_SELECTOR
+WORKLOAD_JOB_TAINT
+WORKLOAD_JOB_PRIVILEGED
+
+KUBECONFIG_FILE
+
+PBENCH_SSH_PRIVATE_KEY_FILE
+PBENCH_SSH_PUBLIC_KEY_FILE
+ENABLE_PBENCH_AGENTS
+PBENCH_SERVER
+
+SCALE_CI_RESULTS_TOKEN
+JOB_COMPLETION_POLL_ATTEMPTS
+
+# Baseline workload specific parameters:
+BASELINE_TEST_PREFIX
+BASELINE_WORKLOAD_DURATION
+```
+
 ## RHCOS NodeVertical Workload
 
 The RHCOS nodevertical workload playbook is `workloads/nodevertical.yml` and will run the nodevertical workload on your RHCOS cluster.

--- a/workloads/baseline.yml
+++ b/workloads/baseline.yml
@@ -1,0 +1,125 @@
+---
+#
+# Runs baseline workload on an existing RHCOS cluster
+#
+
+- name: Runs baseline workload on a RHCOS cluster
+  hosts: orchestration
+  gather_facts: true
+  remote_user: "{{orchestration_user}}"
+  vars_files:
+    - vars/baseline.yml
+  vars:
+    workload_job: "baseline"
+  tasks:
+    - name: Create scale-ci-tooling directory
+      file:
+        path: "{{ansible_user_dir}}/scale-ci-tooling"
+        state: directory
+
+    - name: Copy workload files
+      copy:
+        src: "{{item.src}}"
+        dest: "{{item.dest}}"
+      with_items:
+        - src: scale-ci-tooling-ns.yml
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/scale-ci-tooling-ns.yml"
+
+    - name: Slurp kubeconfig file
+      slurp:
+        src: "{{kubeconfig_file}}"
+      register: kubeconfig_file_slurp
+
+    - name: Slurp ssh private key file
+      slurp:
+        src: "{{pbench_ssh_private_key_file}}"
+      register: pbench_ssh_private_key_file_slurp
+
+    - name: Slurp ssh public key file
+      slurp:
+        src: "{{pbench_ssh_public_key_file}}"
+      register: pbench_ssh_public_key_file_slurp
+
+    - name: Template workload templates
+      template:
+        src: "{{item.src}}"
+        dest: "{{item.dest}}"
+      with_items:
+        - src: pbench-cm.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"
+        - src: pbench-ssh-secret.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-ssh-secret.yml"
+        - src: kubeconfig-secret.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/kubeconfig-secret.yml"
+        - src: workload-job.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
+        - src: workload-baseline-script-cm.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/workload-baseline-script-cm.yml"
+
+    - name: Check if scale-ci-tooling namespace exists
+      shell: |
+        oc get projects | grep "scale-ci-tooling"
+      ignore_errors: true
+      changed_when: false
+      register: scale_ci_tooling_ns_exists
+
+    - name: Ensure any stale scale-ci-baseline job is deleted
+      shell: |
+        oc delete job scale-ci-baseline -n scale-ci-tooling
+      register: scale_ci_tooling_project
+      failed_when: scale_ci_tooling_project.rc == 0
+      until: scale_ci_tooling_project.rc == 1
+      retries: 60
+      delay: 1
+      when: scale_ci_tooling_ns_exists.rc == 0
+
+    - name: Block for non-existing tooling namespace
+      block:
+        - name: Create tooling namespace
+          shell: |
+            oc create -f {{ansible_user_dir}}/scale-ci-tooling/scale-ci-tooling-ns.yml
+
+        - name: Create tooling service account
+          shell: |
+            oc create serviceaccount useroot -n scale-ci-tooling
+            oc adm policy add-scc-to-user privileged -z useroot -n scale-ci-tooling
+          when: enable_pbench_agents|bool
+      when: scale_ci_tooling_ns_exists.rc != 0
+
+    - name: Create/replace kubeconfig secret
+      shell: |
+        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/kubeconfig-secret.yml"
+
+    - name: Create/replace the pbench configmap
+      shell: |
+        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"
+
+    - name: Create/replace pbench ssh secret
+      shell: |
+        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/pbench-ssh-secret.yml"
+
+    - name: Create/replace workload script configmap
+      shell: |
+        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-baseline-script-cm.yml"
+
+    - name: Create/replace workload job to that runs workload script
+      shell: |
+        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
+
+    - name: Poll until job is active
+      shell: |
+        oc get job scale-ci-baseline -n scale-ci-tooling -o json
+      register: job_json
+      retries: 60
+      delay: 2
+      until: job_json.stdout | from_json | json_query('status.active==`1`')
+
+    - name: Poll until job is complete
+      shell: |
+        oc get job scale-ci-baseline -n scale-ci-tooling -o json
+      register: job_json
+      retries: "{{job_completion_poll_attempts}}"
+      delay: 10
+      until: job_json.stdout | from_json | json_query('status.succeeded==`1` || status.failed==`1`')
+      failed_when: job_json.stdout | from_json | json_query('status.succeeded==`1`') == false
+      when: job_completion_poll_attempts|int > 0

--- a/workloads/templates/workload-baseline-script-cm.yml.j2
+++ b/workloads/templates/workload-baseline-script-cm.yml.j2
@@ -7,7 +7,7 @@ data:
     #!/bin/sh
     set -eo pipefail
     # pbench Configuration
-    echo "$(date -u) Configuring pbench for Pod Vertical"
+    echo "$(date -u) Configuring pbench for running Baseline workload"
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     echo "" > /var/lib/pbench-agent/tools-default/oc
@@ -32,52 +32,12 @@ data:
       done
     fi
     source /opt/pbench-agent/profile
-    echo "$(date -u) Done configuring pbench for Pod Vertical"
+    echo "$(date -u) Done configuring pbench for Baseline worload run"
     # End pbench Configuration
 
     # Start of Test Code
-    echo "$(date -u) Running Pod Vertical"
-    pbench-user-benchmark -- 'VIPERCONFIG=/root/workload/podvertical.yaml openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"'
-    pbench-copy-results --prefix {{podvertical_test_prefix}}
-    echo "$(date -u) Completed Pod Vertical"
+    echo "$(date -u) Running Baseline workload"
+    pbench-user-benchmark -- sleep {{baseline_workload_duration}}
+    pbench-copy-results --prefix {{baseline_test_prefix}}
+    echo "$(date -u) Completed Baseline workload run"
     # End of Test Code
-  podvertical.yaml: |
-    provider: local
-    ClusterLoader:
-      cleanup: {{podvertical_cleanup}}
-      projects:
-        - num: 1
-          basename: {{podvertical_basename}}
-          tuning: default
-          ifexists: delete
-          pods:
-            - num: {{podvertical_maxpods}}
-              image: {{podvertical_pod_image}}
-              basename: podvert
-              file: podvert-pod.yaml
-      tuningsets:
-        - name: default
-          pods:
-            stepping:
-              stepsize: {{podvertical_stepsize}}
-              pause: {{podvertical_pause}}
-            ratelimit:
-              delay: 0
-  podvert-pod.yaml: |
-    ---
-    kind: Pod
-    apiVersion: v1
-    metadata:
-      name: podvert
-      labels:
-        name: podvert
-    spec:
-      containers:
-      - name: podvert
-        image: {{podvertical_pod_image}}
-        ports:
-        - containerPort: 8080
-          protocol: TCP
-        imagePullPolicy: IfNotPresent
-        securityContext:
-          privileged: false

--- a/workloads/templates/workload-mastervertical-script-cm.yml.j2
+++ b/workloads/templates/workload-mastervertical-script-cm.yml.j2
@@ -5,6 +5,7 @@ metadata:
 data:
   run.sh: |
     #!/bin/sh
+    set -eo pipefail
     # pbench Configuration
     echo "$(date -u) Configuring pbench for Master Vertical"
     mkdir -p /var/lib/pbench-agent/tools-default/

--- a/workloads/templates/workload-nodevertical-script-cm.yml.j2
+++ b/workloads/templates/workload-nodevertical-script-cm.yml.j2
@@ -5,6 +5,7 @@ metadata:
 data:
   run.sh: |
     #!/bin/sh
+    set -eo pipefail
     # pbench Configuration
     echo "$(date -u) Configuring pbench for Node Vertical"
     mkdir -p /var/lib/pbench-agent/tools-default/

--- a/workloads/vars/baseline.yml
+++ b/workloads/vars/baseline.yml
@@ -1,0 +1,38 @@
+---
+###############################################################################
+# Ansible SSH variables.
+###############################################################################
+ansible_public_key_file: "{{ lookup('env', 'PUBLIC_KEY')|default('~/.ssh/id_rsa.pub', true) }}"
+ansible_private_key_file: "{{ lookup('env', 'PRIVATE_KEY')|default('~/.ssh/id_rsa', true) }}"
+
+orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true) }}"
+###############################################################################
+# RHCOS podvertical workload variables.
+###############################################################################
+
+# Container image in use
+workload_image: "{{ lookup('env', 'WORKLOAD_IMAGE')|default('quay.io/openshift-scale/scale-ci-workload', true) }}"
+
+# Use nodeselector to place workload job on specific node
+workload_job_node_selector: "{{ lookup('env', 'WORKLOAD_JOB_NODE_SELECTOR')|default('', true)|bool }}"
+# Tolerate taint on workload driver
+workload_job_taint: "{{ lookup('env', 'WORKLOAD_JOB_TAINT')|default(true, true)|bool }}"
+# Privileged job container
+workload_job_privileged: "{{ lookup('env', 'WORKLOAD_JOB_PRIVILEGED')|default(true, true)|bool }}"
+
+# Kubeconfig for tooling container script
+kubeconfig_file: "{{ lookup('env', 'KUBECONFIG_FILE')|default('~/.kube/config', true) }}"
+
+# pbench variables
+pbench_ssh_private_key_file: "{{ lookup('env', 'PBENCH_SSH_PRIVATE_KEY_FILE')|default('~/.ssh/id_rsa', true) }}"
+pbench_ssh_public_key_file: "{{ lookup('env', 'PBENCH_SSH_PUBLIC_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"
+enable_pbench_agents: "{{ lookup('env', 'ENABLE_PBENCH_AGENTS')|default(false, true)|bool }}"
+pbench_server: "{{ lookup('env', 'PBENCH_SERVER')|default('', true) }}"
+
+# Other variables for workload tests
+scale_ci_results_token: "{{ lookup('env', 'SCALE_CI_RESULTS_TOKEN')|default('', true) }}"
+job_completion_poll_attempts: "{{ lookup('env', 'JOB_COMPLETION_POLL_ATTEMPTS')|default(360, true)|int }}"
+
+# Idle workload specific parameters:
+baseline_test_prefix: "{{ lookup('env', 'BASELINE_TEST_PREFIX')|default('baseline', true) }}"
+baseline_workload_duration: "{{ lookup('env', 'BASELINE_WORKLOAD_DURATION')|default('15m', true) }}"


### PR DESCRIPTION
Baseline workload allows us to collect pbench data on an cluster not loaded
with any objects. This way we can know about the resources consumed by
the core components including control plane( ApiServer, Etcd, Controller),
kubelet e.t.c and see how the product is moving across various releases.