### PR TITLE
Add deployments per ns cluster limits workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,3 +466,52 @@ NETWORK_TEST_INSTANCES=1,2
 NETWORK_TEST_SAMPLES=3
 NETWORK_TEST_CLEANUP=true
 ```
+
+## Deployments per namespace cluster limits Workload
+
+The Deployments per namespace cluster limits workload playbook is `workloads/cluster-limits-deployments-per-ns.yml` and will run the Deployments per namespace cluster limits test on your RHCOS cluster.
+
+Running from CLI:
+
+```sh
+$ cp workloads/inventory.example inventory
+$ # Add orchestration host to inventory
+$ # Edit vars in workloads/vars/deployments-per-ns.yml or define Environment vars (See below)
+$ time ansible-playbook -vv -i inventory workloads/cluster-limits-deployments-per-ns.yml
+```
+
+### Environment variables for Deployments per namespace cluster limits workload playbook
+
+```
+###############################################################################
+# Ansible SSH variables.
+###############################################################################
+PUBLIC_KEY
+PRIVATE_KEY
+ORCHESTRATION_USER
+
+###############################################################################
+# RHCOS workload variables.
+###############################################################################
+WORKLOAD_IMAGE
+WORKLOAD_JOB_NODE_SELECTOR
+WORKLOAD_JOB_TAINT
+WORKLOAD_JOB_PRIVILEGED
+
+KUBECONFIG_FILE
+
+PBENCH_SSH_PRIVATE_KEY_FILE
+PBENCH_SSH_PUBLIC_KEY_FILE
+ENABLE_PBENCH_AGENTS
+PBENCH_SERVER
+
+SCALE_CI_RESULTS_TOKEN
+JOB_COMPLETION_POLL_ATTEMPTS
+
+# Deployments per namespace cluster limits workload specific parameters:
+DEPLOYMENTS_PER_NS_TEST_PREFIX
+DEPLOYMENTS_PER_NS_CLEANUP
+DEPLOYMENTS_PER_NS_BASENAME
+DEPLOYMENTS_PER_NS_COUNT
+DEPLOYMENTS_PER_NS_POD_IMAGE
+```

--- a/workloads/baseline.yml
+++ b/workloads/baseline.yml
@@ -58,7 +58,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc get project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/cluster-limits-deployments-per-ns.yml
+++ b/workloads/cluster-limits-deployments-per-ns.yml
@@ -1,16 +1,16 @@
 ---
 #
-# Runs MasterVertical on an existing RHCOS cluster
+# Runs deployments-per-ns cluster limits test on an existing RHCOS cluster
 #
 
-- name: Runs MasterVertical on a RHCOS cluster
+- name: Runs deployments-per-ns cluster limits test on a RHCOS cluster
   hosts: orchestration
   gather_facts: true
   remote_user: "{{orchestration_user}}"
   vars_files:
-    - vars/mastervertical.yml
+    - vars/deployments-per-ns.yml
   vars:
-    workload_job: "mastervertical"
+    workload_job: "deployments-per-ns"
   tasks:
     - name: Create scale-ci-tooling directory
       file:
@@ -53,8 +53,8 @@
           dest: "{{ansible_user_dir}}/scale-ci-tooling/kubeconfig-secret.yml"
         - src: workload-job.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
-        - src: workload-mastervertical-script-cm.yml.j2
-          dest: "{{ansible_user_dir}}/scale-ci-tooling/workload-mastervertical-script-cm.yml"
+        - src: workload-deployments-per-ns-script-cm.yml.j2
+          dest: "{{ansible_user_dir}}/scale-ci-tooling/workload-deployments-per-ns-script-cm.yml"
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
@@ -63,9 +63,9 @@
       changed_when: false
       register: scale_ci_tooling_ns_exists
 
-    - name: Ensure any stale scale-ci-mastervertical job is deleted
+    - name: Ensure any stale scale-ci-deployments-per-namespace job is deleted
       shell: |
-        oc delete job scale-ci-mastervertical -n scale-ci-tooling
+        oc delete job scale-ci-deployments-per-ns -n scale-ci-tooling
       register: scale_ci_tooling_project
       failed_when: scale_ci_tooling_project.rc == 0
       until: scale_ci_tooling_project.rc == 1
@@ -100,7 +100,7 @@
 
     - name: Create/replace workload script configmap
       shell: |
-        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-mastervertical-script-cm.yml"
+        oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-deployments-per-ns-script-cm.yml"
 
     - name: Create/replace workload job to that runs workload script
       shell: |
@@ -108,7 +108,7 @@
 
     - name: Poll until job is active
       shell: |
-        oc get job scale-ci-mastervertical -n scale-ci-tooling -o json
+        oc get job scale-ci-deployments-per-ns -n scale-ci-tooling -o json
       register: job_json
       retries: 60
       delay: 2
@@ -116,7 +116,7 @@
 
     - name: Poll until job is complete
       shell: |
-        oc get job scale-ci-mastervertical -n scale-ci-tooling -o json
+        oc get job scale-ci-deployments-per-ns -n scale-ci-tooling -o json
       register: job_json
       retries: "{{job_completion_poll_attempts}}"
       delay: 10

--- a/workloads/http.yml
+++ b/workloads/http.yml
@@ -63,7 +63,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc get project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/network.yml
+++ b/workloads/network.yml
@@ -76,7 +76,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/nodevertical.yml
+++ b/workloads/nodevertical.yml
@@ -86,7 +86,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc get project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/podvertical.yml
+++ b/workloads/podvertical.yml
@@ -58,7 +58,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc get project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/templates/workload-deployments-per-ns-script-cm.yml.j2
+++ b/workloads/templates/workload-deployments-per-ns-script-cm.yml.j2
@@ -1,0 +1,126 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: scale-ci-workload-script
+data:
+  run.sh: |
+    #!/bin/sh
+    set -eo pipefail
+    # pbench Configuration
+    echo "$(date -u) Configuring pbench for Deployments per namespace cluster limits test"
+    mkdir -p /var/lib/pbench-agent/tools-default/
+    echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
+    echo "" > /var/lib/pbench-agent/tools-default/oc
+    echo "workload" > /var/lib/pbench-agent/tools-default/label
+    if [[ -v ENABLE_PBENCH_AGENTS ]]; then
+      echo "" > /var/lib/pbench-agent/tools-default/disk
+      echo "" > /var/lib/pbench-agent/tools-default/iostat
+      echo "" > /var/lib/pbench-agent/tools-default/mpstat
+      echo "" > /var/lib/pbench-agent/tools-default/perf
+      echo "" > /var/lib/pbench-agent/tools-default/pidstat
+      master_nodes=`oc get nodes -l pbench_agent=true,node-role.kubernetes.io/master= --no-headers | awk '{print $1}'`
+      for node in $master_nodes; do
+        echo "master" > /var/lib/pbench-agent/tools-default/remote@$node
+      done
+      infra_nodes=`oc get nodes -l pbench_agent=true,node-role.kubernetes.io/infra= --no-headers | awk '{print $1}'`
+      for node in $infra_nodes; do
+        echo "infra" > /var/lib/pbench-agent/tools-default/remote@$node
+      done
+      worker_nodes=`oc get nodes -l pbench_agent=true,node-role.kubernetes.io/worker= --no-headers | awk '{print $1}'`
+      for node in $worker_nodes; do
+        echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
+      done
+    fi
+    source /opt/pbench-agent/profile
+    echo "$(date -u) Done configuring pbench for Deployments per ns cluster limits test"
+    # End pbench Configuration
+
+    # Start of Test Code
+    echo "$(date -u) Running Deployments per ns cluster limits test"
+    pbench-user-benchmark -- 'VIPERCONFIG=/root/workload/cluster-limits-deployments-per-namespace.yaml openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster should load the cluster [Suite:openshift]"'
+    pbench-copy-results --prefix {{deployments_per_ns_test_prefix}}
+    echo "$(date -u) Completed running Deployments per ns cluster limits test"
+    # End of Test Code
+  
+  cluster-limits-deployments-per-namespace.yaml: |
+    provider: local
+    ClusterLoader:
+      cleanup: {{deployments_per_ns_cleanup}}
+      projects:
+        - num: 1
+          basename: {{deployments_per_ns_basename}}
+          ifexists: delete
+          templates:
+            - num: {{deployments_per_ns_count}}
+              file: deployment-config-cluster-limits-deployments.yaml
+              parameters:
+                - ENV_VALUE: "asodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij0emc2oed2ed2ed2e2easodfn209e8j0eij12"
+                - IMAGE: {{deployments_per_ns_pod_image}}
+  deployment-config-cluster-limits-deployments.yaml: |
+    ---
+    Kind: Template
+    apiVersion: v1
+    metadata:
+      name: deploymentConfigTemplate
+      creationTimestamp: 
+      annotations:
+        description: This template will create a deploymentConfig with 1 replica and 4
+          env vars
+        tags: ''
+    objects:
+    - kind: DeploymentConfig
+      apiVersion: v1
+      metadata:
+        name: deploymentconfig${IDENTIFIER}
+      spec:
+        template:
+          metadata:
+            labels:
+              name: replicationcontroller${IDENTIFIER}
+          spec:
+            containers:
+            - name: dpns${IDENTIFIER}
+              image: "${IMAGE}"
+              ports:
+              - containerPort: 8080
+                protocol: TCP
+              env:
+              - name: ENVVAR1_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              - name: ENVVAR2_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              - name: ENVVAR3_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              - name: ENVVAR4_${IDENTIFIER}
+                value: "${ENV_VALUE}"
+              resources: {}
+              imagePullPolicy: IfNotPresent
+              capabilities: {}
+              securityContext:
+                capabilities: {}
+                privileged: false
+            restartPolicy: Always
+            serviceAccount: ''
+        replicas: 1
+        selector:
+          name: replicationcontroller${IDENTIFIER}
+        triggers:
+        - type: ConfigChange
+        strategy:
+          type: Rolling
+    parameters:
+    - name: IDENTIFIER
+      description: Number to append to the name of resources
+      value: '1'
+      required: true
+    - name: IMAGE
+      description: Image to use for deploymentConfig
+      value: "gcr.io/google-containers/pause-amd64:3.0"
+      required: false
+    - name: ENV_VALUE
+      description: Value to use for environment variables
+      generate: expression
+      from: "[A-Za-z0-9]{255}"
+      required: false
+    labels:
+      template: deploymentConfigTemplate 

--- a/workloads/test.yml
+++ b/workloads/test.yml
@@ -62,7 +62,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc get project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/tooling.yml
+++ b/workloads/tooling.yml
@@ -64,7 +64,7 @@
 
     - name: Check if scale-ci-tooling namespace exists
       shell: |
-        oc get projects | grep "scale-ci-tooling"
+        oc get project scale-ci-tooling
       ignore_errors: true
       changed_when: false
       register: scale_ci_tooling_ns_exists

--- a/workloads/vars/deployments-per-ns.yml
+++ b/workloads/vars/deployments-per-ns.yml
@@ -1,0 +1,41 @@
+---
+###############################################################################
+# Ansible SSH variables.
+###############################################################################
+ansible_public_key_file: "{{ lookup('env', 'PUBLIC_KEY')|default('~/.ssh/id_rsa.pub', true) }}"
+ansible_private_key_file: "{{ lookup('env', 'PRIVATE_KEY')|default('~/.ssh/id_rsa', true) }}"
+
+orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true) }}"
+###############################################################################
+# Deployments per namespace cluster limits workload variables.
+###############################################################################
+
+# Container image in use
+workload_image: "{{ lookup('env', 'WORKLOAD_IMAGE')|default('quay.io/openshift-scale/scale-ci-workload', true) }}"
+
+# Use nodeselector to place workload job on specific node
+workload_job_node_selector: "{{ lookup('env', 'WORKLOAD_JOB_NODE_SELECTOR')|default('', true)|bool }}"
+# Tolerate taint on workload driver
+workload_job_taint: "{{ lookup('env', 'WORKLOAD_JOB_TAINT')|default(true, true)|bool }}"
+# Privileged job container
+workload_job_privileged: "{{ lookup('env', 'WORKLOAD_JOB_PRIVILEGED')|default(true, true)|bool }}"
+
+# Kubeconfig for tooling container script
+kubeconfig_file: "{{ lookup('env', 'KUBECONFIG_FILE')|default('~/.kube/config', true) }}"
+
+# pbench variables
+pbench_ssh_private_key_file: "{{ lookup('env', 'PBENCH_SSH_PRIVATE_KEY_FILE')|default('~/.ssh/id_rsa', true) }}"
+pbench_ssh_public_key_file: "{{ lookup('env', 'PBENCH_SSH_PUBLIC_KEY_FILE')|default('~/.ssh/id_rsa.pub', true) }}"
+enable_pbench_agents: "{{ lookup('env', 'ENABLE_PBENCH_AGENTS')|default(false, true)|bool }}"
+pbench_server: "{{ lookup('env', 'PBENCH_SERVER')|default('', true) }}"
+
+# Other variables for workload tests
+scale_ci_results_token: "{{ lookup('env', 'SCALE_CI_RESULTS_TOKEN')|default('', true) }}"
+job_completion_poll_attempts: "{{ lookup('env', 'JOB_COMPLETION_POLL_ATTEMPTS')|default(360, true)|int }}"
+
+# Deployments per namespace cluster limis workload specific parameters:
+deployments_per_ns_test_prefix: "{{ lookup('env', 'DEPLOYMENTS_PER_NS_TEST_PREFIX')|default('deployments_per_ns', true) }}"
+deployments_per_ns_cleanup: "{{ lookup('env', 'DEPLOYMENTS_PER_NS_CLEANUP')|default(true, true)|bool|lower }}"
+deployments_per_ns_basename: "{{ lookup('env', 'DEPLOYMENTS_PER_NS_BASENAME')|default('deployments-per-ns', true) }}"
+deployments_per_ns_count: "{{ lookup('env', 'DEPLOYMENTS_PER_NS_COUNT')|default(2000, true)|int }}"
+deployments_per_ns_pod_image: "{{ lookup('env', 'DEPLOYMENTS_PER_NS_POD_IMAGE')|default('gcr.io/google_containers/pause-amd64:3.0', true) }}"


### PR DESCRIPTION
This workload creates desired deployments per ns to test the current
OCP limit as well as push the limit.