### PR TITLE
Cleanup the unwanted daemonsets mounts

### DIFF
--- a/workloads/templates/pbench-infra-ds.yml.j2
+++ b/workloads/templates/pbench-infra-ds.yml.j2
@@ -40,13 +40,6 @@ spec:
           subPath: id_rsa.pub
         - name: pbench-agent-infra-tools
           mountPath: /var/lib/pbench-agent/tools-default
-
-        - name: proc-mount
-          mountPath: /proc_host
-        - name: admin-keys
-          mountPath: /etc/origin/master
-        - name: certs
-          mountPath: /etc/pki
         - name: ocp-volumes
           mountPath: /var/lib/kubelet/pods
         ports:
@@ -62,16 +55,6 @@ spec:
       - name: pbench-agent-infra-tools
         configMap:
           name: pbench-agent-infra-tools
-
-      - name: proc-mount
-        hostPath:
-          path: /proc
-      - name: admin-keys
-        hostPath:
-          path: /etc/origin/master
-      - name: certs
-        hostPath:
-          path: /etc/pki
       - name: ocp-volumes
         hostPath:
           path: /var/lib/kubelet/pods

--- a/workloads/templates/pbench-master-ds.yml.j2
+++ b/workloads/templates/pbench-master-ds.yml.j2
@@ -40,13 +40,6 @@ spec:
           subPath: id_rsa.pub
         - name: pbench-agent-master-tools
           mountPath: /var/lib/pbench-agent/tools-default
-
-        - name: proc-mount
-          mountPath: /proc_host
-        - name: admin-keys
-          mountPath: /etc/origin/master
-        - name: certs
-          mountPath: /etc/pki
         - name: ocp-volumes
           mountPath: /var/lib/kubelet/pods
         ports:
@@ -62,16 +55,6 @@ spec:
       - name: pbench-agent-master-tools
         configMap:
           name: pbench-agent-master-tools
-
-      - name: proc-mount
-        hostPath:
-          path: /proc
-      - name: admin-keys
-        hostPath:
-          path: /etc/origin/master
-      - name: certs
-        hostPath:
-          path: /etc/pki
       - name: ocp-volumes
         hostPath:
           path: /var/lib/kubelet/pods

--- a/workloads/templates/pbench-worker-ds.yml.j2
+++ b/workloads/templates/pbench-worker-ds.yml.j2
@@ -40,13 +40,6 @@ spec:
           subPath: id_rsa.pub
         - name: pbench-agent-worker-tools
           mountPath: /var/lib/pbench-agent/tools-default
-
-        - name: proc-mount
-          mountPath: /proc_host
-        - name: admin-keys
-          mountPath: /etc/origin/master
-        - name: certs
-          mountPath: /etc/pki
         - name: ocp-volumes
           mountPath: /var/lib/kubelet/pods
         ports:
@@ -62,16 +55,6 @@ spec:
       - name: pbench-agent-worker-tools
         configMap:
           name: pbench-agent-worker-tools
-
-      - name: admin-keys
-        hostPath:
-          path: /etc/origin/master
-      - name: certs
-        hostPath:
-          path: /etc/pki
-      - name: proc-mount
-        hostPath:
-          path: /proc
       - name: ocp-volumes
         hostPath:
           path: /var/lib/kubelet/pods


### PR DESCRIPTION
We used to mount proc and certs from te host onto the agent containers
for some of the tools like prometheus metrics, we no longer need them
as we are using scale-ci-promdump and scraper for collection and analysis.