### PR TITLE
Set KUBECONFIG environment variable

### DIFF
--- a/workloads/baseline.yml
+++ b/workloads/baseline.yml
@@ -11,6 +11,8 @@
     - vars/baseline.yml
   vars:
     workload_job: "baseline"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/cluster-limits-deployments-per-ns.yml
+++ b/workloads/cluster-limits-deployments-per-ns.yml
@@ -11,6 +11,8 @@
     - vars/deployments-per-ns.yml
   vars:
     workload_job: "deployments-per-ns"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/http.yml
+++ b/workloads/http.yml
@@ -12,6 +12,8 @@
   vars:
     workload_job: "http"
     workload_job_privileged: "{{enable_pbench_agents}}"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/mastervertical.yml
+++ b/workloads/mastervertical.yml
@@ -11,6 +11,8 @@
     - vars/mastervertical.yml
   vars:
     workload_job: "mastervertical"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/network.yml
+++ b/workloads/network.yml
@@ -11,6 +11,8 @@
     - vars/network.yml
   vars:
     workload_job: "network"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/nodevertical.yml
+++ b/workloads/nodevertical.yml
@@ -11,6 +11,8 @@
     - vars/nodevertical.yml
   vars:
     workload_job: "nodevertical"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/podvertical.yml
+++ b/workloads/podvertical.yml
@@ -11,6 +11,8 @@
     - vars/podvertical.yml
   vars:
     workload_job: "podvertical"
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/test.yml
+++ b/workloads/test.yml
@@ -15,6 +15,8 @@
     workload_job_privileged: true
     workload_job_node_selector: true
     workload_job_taint: true
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:

--- a/workloads/tooling.yml
+++ b/workloads/tooling.yml
@@ -9,6 +9,8 @@
   remote_user: "{{orchestration_user}}"
   vars_files:
     - vars/tooling.yml
+  environment:
+    KUBECONFIG: "{{ kubeconfig_file }}"
   tasks:
     - name: Create scale-ci-tooling directory
       file:


### PR DESCRIPTION
This is needed for the client to talk to apiserver when the kubeconfig
is not at the default path i.e $HOME/.kube/config.