### PR TITLE
Wait until workload pod is Running instead of Job active

### DIFF
--- a/workloads/baseline.yml
+++ b/workloads/baseline.yml
@@ -106,13 +106,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-baseline -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-baseline -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/cluster-limits-deployments-per-ns.yml
+++ b/workloads/cluster-limits-deployments-per-ns.yml
@@ -106,13 +106,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-deployments-per-ns -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-deployments-per-ns -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/http.yml
+++ b/workloads/http.yml
@@ -113,13 +113,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-http -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-http -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/mastervertical.yml
+++ b/workloads/mastervertical.yml
@@ -106,13 +106,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-mastervertical -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-mastervertical -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/network.yml
+++ b/workloads/network.yml
@@ -128,13 +128,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-network -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-network -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/nodevertical.yml
+++ b/workloads/nodevertical.yml
@@ -142,13 +142,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-nodevertical -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-nodevertical -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/podvertical.yml
+++ b/workloads/podvertical.yml
@@ -106,13 +106,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-podvertical -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-podvertical -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/pvcscale.yml
+++ b/workloads/pvcscale.yml
@@ -118,13 +118,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-pvcscale -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-pvcscale -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |

--- a/workloads/scale.yml
+++ b/workloads/scale.yml
@@ -112,13 +112,13 @@
       shell: |
         oc replace --force -n scale-ci-tooling -f "{{ansible_user_dir}}/scale-ci-tooling/workload-job.yml"
 
-    - name: Poll until job is active
+    - name: Poll until job pod is running
       shell: |
-        oc get job scale-ci-scale -n scale-ci-tooling -o json
-      register: job_json
+        oc get pods --selector=job-name=scale-ci-scale -n scale-ci-tooling -o json
+      register: pod_json
       retries: 60
       delay: 2
-      until: job_json.stdout | from_json | json_query('status.active==`1`')
+      until: pod_json.stdout | from_json | json_query('items[0].status.phase==`Running`')
 
     - name: Poll until job is complete
       shell: |


### PR DESCRIPTION
Turns out the job can be active but the pod not actually running. Wait until the pod is running allows CI to stream pod logs with little effort.