### PR TITLE
Set lstrip_blocks for jinja templating

### DIFF
--- a/workloads/baseline.yml
+++ b/workloads/baseline.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/cluster-limits-deployments-per-ns.yml
+++ b/workloads/cluster-limits-deployments-per-ns.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/cluster-limits-namespaces-per-cluster.yml
+++ b/workloads/cluster-limits-namespaces-per-cluster.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/cluster-limits-services-per-ns.yml
+++ b/workloads/cluster-limits-services-per-ns.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/conformance.yml
+++ b/workloads/conformance.yml
@@ -46,6 +46,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/fio.yml
+++ b/workloads/fio.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/http.yml
+++ b/workloads/http.yml
@@ -47,6 +47,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/mastervertical.yml
+++ b/workloads/mastervertical.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/network.yml
+++ b/workloads/network.yml
@@ -60,6 +60,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/nodevertical.yml
+++ b/workloads/nodevertical.yml
@@ -80,6 +80,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/podvertical.yml
+++ b/workloads/podvertical.yml
@@ -45,6 +45,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/prometheus.yml
+++ b/workloads/prometheus.yml
@@ -46,6 +46,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/pvcscale.yml
+++ b/workloads/pvcscale.yml
@@ -44,6 +44,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/test.yml
+++ b/workloads/test.yml
@@ -50,6 +50,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"

--- a/workloads/tooling.yml
+++ b/workloads/tooling.yml
@@ -48,6 +48,7 @@
       template:
         src: "{{item.src}}"
         dest: "{{item.dest}}"
+        lstrip_blocks: yes
       with_items:
         - src: pbench-cm.yml.j2
           dest: "{{ansible_user_dir}}/scale-ci-tooling/pbench-cm.yml"


### PR DESCRIPTION
This will strip the leading spaces and tabs.