### PR TITLE
Restrict workloads on worker nodes

### DIFF
--- a/workloads/templates/workload-deployments-per-ns-script-cm.yml.j2
+++ b/workloads/templates/workload-deployments-per-ns-script-cm.yml.j2
@@ -58,6 +58,7 @@ data:
         - num: 1
           basename: {{deployments_per_ns_basename}}
           ifexists: delete
+          nodeselector: "node-role.kubernetes.io/worker="
           templates:
             - num: {{deployments_per_ns_count}}
               file: deployment-config-cluster-limits-deployments.yaml

--- a/workloads/templates/workload-fio-script-cm.yml.j2
+++ b/workloads/templates/workload-fio-script-cm.yml.j2
@@ -107,6 +107,7 @@ data:
         - num: 1
           basename: {{ fiotest_basename }}
           ifexists: delete
+          nodeselector: "node-role.kubernetes.io/worker="
           nodeselector: {{ fiotest_nodeselector }}
           templates:
             - num: 1

--- a/workloads/templates/workload-mastervertical-script-cm.yml.j2
+++ b/workloads/templates/workload-mastervertical-script-cm.yml.j2
@@ -105,6 +105,7 @@ data:
         - num: ${MASTERVERTICAL_PROJECTS}
           basename: ${MASTERVERTICAL_BASENAME}
           ifexists: delete
+          nodeselector: "node-role.kubernetes.io/worker="
           templates:
             - num: 3
               file: /root/workload/build-config-template.yaml

--- a/workloads/templates/workload-namespaces-per-cluster-script-cm.yml.j2
+++ b/workloads/templates/workload-namespaces-per-cluster-script-cm.yml.j2
@@ -105,6 +105,7 @@ data:
         - num: ${NAMESPACES_PER_CLUSTER_COUNT}
           basename: ${NAMESPACES_PER_CLUSTER_BASENAME}
           ifexists: reuse
+          nodeselector: "node-role.kubernetes.io/worker="
           templates:
             - num: 1
               file: /root/workload/bc-imagestream-template.yaml

--- a/workloads/templates/workload-network-script-cm.yml.j2
+++ b/workloads/templates/workload-network-script-cm.yml.j2
@@ -166,6 +166,7 @@ data:
       - num: 1
         basename: "${NETWORK_TEST_BASENAME}"
         ifexists: delete
+        nodeselector: "node-role.kubernetes.io/worker="
         templates:
         - num: 1
           file: /root/workload/pbench-ssh.yaml

--- a/workloads/templates/workload-nodevertical-script-cm.yml.j2
+++ b/workloads/templates/workload-nodevertical-script-cm.yml.j2
@@ -107,6 +107,7 @@ data:
           basename: ${NODEVERTICAL_BASENAME}
           tuning: default
           ifexists: delete
+          nodeselector: "node-role.kubernetes.io/worker="
           pods:
             - num: ${TOTAL_POD_COUNT}
               basename: nodevert

--- a/workloads/templates/workload-podvertical-script-cm.yml.j2
+++ b/workloads/templates/workload-podvertical-script-cm.yml.j2
@@ -107,6 +107,7 @@ data:
           basename: ${PODVERTICAL_BASENAME}
           tuning: default
           ifexists: delete
+          nodeselector: "node-role.kubernetes.io/worker="
           pods:
             - num: ${PODVERTICAL_MAXPODS}
               basename: podvert

--- a/workloads/templates/workload-services-per-namespace-script-cm.yml.j2
+++ b/workloads/templates/workload-services-per-namespace-script-cm.yml.j2
@@ -105,6 +105,7 @@ data:
         - num: ${SERVICES_PER_NAMESPACE_PROJECTS}
           basename: ${SERVICES_PER_NAMESPACE_BASENAME}
           ifexists: delete
+          nodeselector: "node-role.kubernetes.io/worker="
           templates:
             - num: ${SERVICES_PER_NAMESPACE_COUNT}
               file: /root/workload/deployment-config-cluster-limits-services.yaml


### PR DESCRIPTION
This commit will make sure all the objects created by the workloads
land on worker nodes instead of spreading across the cluster which
is a problem when there are infra nodes meant to run just
prometheus, router and registry.