### PR TITLE
workload objects will land on worker nodes

### DIFF
--- a/workloads/files/workload-http-script-cm.yml
+++ b/workloads/files/workload-http-script-cm.yml
@@ -932,6 +932,7 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
+            nodeSelector: "node-role.kubernetes.io/worker="
             restartPolicy: Always
     - apiVersion: v1
       kind: Route
@@ -1012,6 +1013,7 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
+            nodeSelector: "node-role.kubernetes.io/worker="
             restartPolicy: Always
     - apiVersion: v1
       kind: Route
@@ -1096,6 +1098,7 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
+            nodeSelector: "node-role.kubernetes.io/worker="
             restartPolicy: Always
     - apiVersion: v1
       kind: Route
@@ -1178,6 +1181,7 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
+            nodeSelector: "node-role.kubernetes.io/worker="
             restartPolicy: Always
     - apiVersion: v1
       kind: Route


### PR DESCRIPTION
This commit will make sure all the objects created by http workload land on worker nodes instead of spreading across the cluster @jtaleric @chaitanyaenr 