### PR TITLE
fixing mastervert to use parallel cl

### DIFF
--- a/docs/mastervertical.md
+++ b/docs/mastervertical.md
@@ -15,18 +15,6 @@ $ time ansible-playbook -vv -i inventory workloads/mastervertical.yml
 
 ## Environment variables
 
-### ES_HOST
-Default: ``
-Elasticsearch server host address (currently used by snafu), set to index results from cluster loader
-
-### ES_PORT
-Default: ``
-Elasticsearch server port (currently used by snafu), set to index results from cluster loader
-
-### ES_INDEX_PREFIX
-Default: `snafu`
-Elasticsearch server index prefix (currently used by snafu)
-
 ### PUBLIC_KEY
 Default: `~/.ssh/id_rsa.pub`  
 Public ssh key file for Ansible.

--- a/workloads/templates/workload-mastervertical-script-cm.yml.j2
+++ b/workloads/templates/workload-mastervertical-script-cm.yml.j2
@@ -83,10 +83,7 @@ data:
       export AZURE_AUTH_LOCATION=/tmp/azure_auth
     fi
     start_time=$(date +%s)
-    export es={{ snafu_es_host }}
-    export es_port={{ snafu_es_port }}
-    export es_index={{ snafu_es_index_prefix }}
-    VIPERCONFIG=/tmp/mastervertical.yaml python /tmp/snafu/run_snafu.py -t cl scale-ci --cl-output True --dir "${result_dir}" -p openshift-tests | tee "${result_dir}/clusterloader.txt"
+    VIPERCONFIG=/tmp/mastervertical.yaml openshift-tests run-test "[Feature:Performance][Serial][Slow] Load cluster concurrently with templates [Suite:openshift]" | tee "${result_dir}/clusterloader.txt"
     exit_code=$?
     end_time=$(date +%s)
     duration=$((end_time-start_time))


### PR DESCRIPTION
Replacing the snafu invocation with the original parallel invocation of cluster loader, as snafu's cl doesn't support the parallel invocation yet.