### PR TITLE
http workload will land on worker node, fix to PR 105

### DIFF
--- a/workloads/files/workload-http-script-cm.yml
+++ b/workloads/files/workload-http-script-cm.yml
@@ -932,7 +932,8 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
-            nodeSelector: "node-role.kubernetes.io/worker="
+            nodeSelector:
+              "node-role.kubernetes.io/worker": ''
             restartPolicy: Always
     - apiVersion: v1
       kind: Route
@@ -1013,7 +1014,8 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
-            nodeSelector: "node-role.kubernetes.io/worker="
+            nodeSelector: 
+              "node-role.kubernetes.io/worker": ''
             restartPolicy: Always
     - apiVersion: v1
       kind: Route
@@ -1098,7 +1100,8 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
-            nodeSelector: "node-role.kubernetes.io/worker="
+            nodeSelector: 
+              "node-role.kubernetes.io/worker": ''
             restartPolicy: Always
     - apiVersion: v1
       kind: Route
@@ -1181,7 +1184,8 @@ data:
                   - SETUID
                   - SYS_CHROOT
                 privileged: false
-            nodeSelector: "node-role.kubernetes.io/worker="
+            nodeSelector: 
+              "node-role.kubernetes.io/worker": ''
             restartPolicy: Always
     - apiVersion: v1
       kind: Route


### PR DESCRIPTION
PR 105 (https://github.com/openshift-scale/workloads/pull/105) was able to get pods stick to worker nodes but it introduced another error 

`Error from server (BadRequest): ReplicationController in version "v1" cannot be handled as a ReplicationController: v1.ReplicationController.Spec: v1.ReplicationControllerSpec.Template: v1.PodTemplateSpec.Spec: v1.PodSpec.NodeSelector: ReadMapCB: expect { or n, but found ", error found in #10 byte of ...|elector":"node-role.|..., bigger context ...|S_CHROOT"]},"privileged":false}}],"nodeSelector":"node-role.kubernetes.io/worker=","restartPolicy":"|...`

This commit fixes the above error

@chaitanyaenr @jtaleric 