### PR TITLE
Inspect kube-apiserver and kube-controllermanager operators

### DIFF
--- a/workloads/templates/workload-mastervertical-script-cm.yml.j2
+++ b/workloads/templates/workload-mastervertical-script-cm.yml.j2
@@ -90,11 +90,14 @@ data:
     exit_code=$?
     end_time=$(date +%s)
     duration=$((end_time-start_time))
-
     workload_log "Writing Cluster Loader Exit Code"
     jq -n '. | ."exit_code"='${exit_code}' | ."duration"='${duration}'' > "${result_dir}/exit.json"
     workload_log "Writing Cluster Loader Metrics to clusterloader.json"
     grep "cluster_loader_marker" ${result_dir}/clusterloader.txt > "${result_dir}/clusterloader.json"
+    if [[ ${profile_cluster_ops} == "true" ]]; then
+      workload_log "Collecting profiling information from kube-controller-manager and kube-apiserver"
+      oc adm inspect co/kube-apiserver co/kube-controller-manager --dest-dir ${result_dir}/profiling_info
+    fi
 
     workload_log "Finished workload script"
   mastervertical.yaml.template: |

--- a/workloads/templates/workload-nodevertical-script-cm.yml.j2
+++ b/workloads/templates/workload-nodevertical-script-cm.yml.j2
@@ -96,6 +96,10 @@ data:
     jq -n '. | ."exit_code"='${exit_code}' | ."duration"='${duration}'' > "${result_dir}/exit.json"
     workload_log "Writing Cluster Loader Metrics to clusterloader.json"
     grep "cluster_loader_marker" ${result_dir}/clusterloader.txt > "${result_dir}/clusterloader.json"
+    if [[ ${profile_cluster_ops} == "true" ]]; then
+      workload_log "Collecting profiling information from kube-controller-manager and kube-apiserver"
+      oc adm inspect co/kube-apiserver co/kube-controller-manager --dest-dir ${result_dir}/profiling_info
+    fi
 
     workload_log "Finished workload script"
   nodevertical.yaml.template: |

--- a/workloads/templates/workload-podvertical-script-cm.yml.j2
+++ b/workloads/templates/workload-podvertical-script-cm.yml.j2
@@ -96,6 +96,10 @@ data:
     jq -n '. | ."exit_code"='${exit_code}' | ."duration"='${duration}'' > "${result_dir}/exit.json"
     workload_log "Writing Cluster Loader Metrics to clusterloader.json"
     grep "cluster_loader_marker" ${result_dir}/clusterloader.txt > "${result_dir}/clusterloader.json"
+    if [[ ${profile_cluster_ops} == "true" ]]; then
+      workload_log "Collecting profiling information from kube-controller-manager and kube-apiserver"
+      oc adm inspect co/kube-apiserver co/kube-controller-manager --dest-dir ${result_dir}/profiling_info
+    fi
 
     workload_log "Finished workload script"
   podvertical.yaml.template: |

--- a/workloads/vars/mastervertical.yml
+++ b/workloads/vars/mastervertical.yml
@@ -46,3 +46,6 @@ mastervertical_projects: "{{ lookup('env', 'MASTERVERTICAL_PROJECTS')|default(10
 
 # Pass/fail criteria
 expected_mastervertical_duration: "{{ lookup('env', 'EXPECTED_MASTERVERTICAL_DURATION')|default(600, true)|int }}"
+
+# Collect kube-apiserver and kube controller manager profiling data
+profile_cluster_ops: "{{ lookup('env', 'PROFILE_CLUSTER_OPS')|default(true, true)|bool }}'

--- a/workloads/vars/nodevertical.yml
+++ b/workloads/vars/nodevertical.yml
@@ -51,3 +51,6 @@ nodevertical_ts_timeout: "{{ lookup('env', 'NODEVERTICAL_TS_TIMEOUT')|default(18
 
 # Pass/fail criteria
 expected_nodevertical_duration: "{{ lookup('env', 'EXPECTED_NODEVERTICAL_DURATION')|default(600, true)|int }}"
+
+# Collect kube-apiserver and kube controller manager profiling data
+profile_cluster_ops: "{{ lookup('env', 'PROFILE_CLUSTER_OPS')|default(true, true)|bool }}'

--- a/workloads/vars/podvertical.yml
+++ b/workloads/vars/podvertical.yml
@@ -50,3 +50,6 @@ podvertical_ts_timeout: "{{ lookup('env', 'PODVERTICAL_TS_TIMEOUT')|default(600,
 
 # Pass/fail criteria
 expected_podvertical_duration: "{{ lookup('env', 'EXPECTED_PODVERTICAL_DURATION')|default(600, true)|int }}"
+
+# Collect kube-apiserver and kube controller manager profiling data
+profile_cluster_ops: "{{ lookup('env', 'PROFILE_CLUSTER_OPS')|default(true, true)|bool }}'


### PR DESCRIPTION
The `oc` command provides an OOTB way to get profiling information from the clusteroperators through the `oc adm inspect clusteroperator/<operator_name>`
This PR aims to execute this command to collect that information by default on mastervert, nodevert and podvert workloads.