### PR TITLE
Avoid using infra nodes on OSD when selecting workers.

### DIFF
--- a/workloads/network.yml
+++ b/workloads/network.yml
@@ -46,14 +46,14 @@
 
     - name: Label worker nodes with pbench agent for network tests
       shell: |
-        oc get nodes --no-headers -l pbench_agent=true,node-role.kubernetes.io/worker= | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=client
-        oc get nodes --no-headers --show-labels -l pbench_agent=true,node-role.kubernetes.io/worker= | grep -v uperf=client | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=server
+        oc get nodes --no-headers -l pbench_agent=true,node-role.kubernetes.io/worker= | grep -v infra | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=client
+        oc get nodes --no-headers --show-labels -l pbench_agent=true,node-role.kubernetes.io/worker= | grep -v infra | grep -v uperf=client | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=server
       when: enable_pbench_agents|bool
 
     - name: Label worker nodes when there are no pbench agents for network tests
       shell: |
-        oc get nodes --no-headers -l node-role.kubernetes.io/worker= | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=client
-        oc get nodes --no-headers --show-labels -l node-role.kubernetes.io/worker= | grep -v uperf=client | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=server
+        oc get nodes --no-headers -l node-role.kubernetes.io/worker= | grep -v infra | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=client
+        oc get nodes --no-headers --show-labels -l node-role.kubernetes.io/worker= | grep -v infra | grep -v uperf=client | head -n 1 | awk '{print $1}' | xargs -I % oc label nodes % uperf=server
       when: not enable_pbench_agents|bool
 
     - name: Block to set clustername

--- a/workloads/nodevertical.yml
+++ b/workloads/nodevertical.yml
@@ -49,22 +49,22 @@
       block:
         - name: Label worker nodes with pbench agent for nodevertical (NODEVERTICAL_NODE_COUNT < 2)
           shell: |
-            oc get nodes -l pbench_agent=true,node-role.kubernetes.io/worker= --no-headers | head -n {{nodevertical_node_count}} | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
+            oc get nodes -l pbench_agent=true,node-role.kubernetes.io/worker= --no-headers | grep -v infra | head -n {{nodevertical_node_count}} | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
           when: nodevertical_node_count|int <= 2
 
         - name: Label worker nodes with pbench agent for nodevertical (NODEVERTICAL_NODE_COUNT > 2)
           shell: |
-            oc get nodes -l pbench_agent=true,node-role.kubernetes.io/worker= --no-headers | head -n 2 | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
+            oc get nodes -l pbench_agent=true,node-role.kubernetes.io/worker= --no-headers | grep -v infra | head -n 2 | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
           when: nodevertical_node_count|int > 2
 
         - name: Label worker nodes without pbench agent for nodevertical (NODEVERTICAL_NODE_COUNT > 2)
           shell: |
-            oc get nodes -l node-role.kubernetes.io/worker= --show-labels --no-headers | grep -v "pbench_agent=true" | head -n {{nodevertical_node_count|int -2}} | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
+            oc get nodes -l node-role.kubernetes.io/worker= --show-labels --no-headers | grep -v infra | grep -v "pbench_agent=true" | head -n {{nodevertical_node_count|int -2}} | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
           when: nodevertical_node_count|int > 2
 
     - name: Label worker nodes when there are no pbench agents
       shell: |
-        oc get nodes -l node-role.kubernetes.io/worker= --no-headers | head -n {{nodevertical_node_count}} | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
+        oc get nodes -l node-role.kubernetes.io/worker= --no-headers | grep -v infra | head -n {{nodevertical_node_count}} | awk '{print $1}' | xargs -I % oc label nodes % nodevertical=true
       when: not enable_pbench_agents|bool
 
     - name: Calculate maximum pods to fit in nodevertical labeled space

--- a/workloads/templates/pbench-worker-ds.yml.j2
+++ b/workloads/templates/pbench-worker-ds.yml.j2
@@ -62,6 +62,16 @@ spec:
         hostPath:
           path: /var/lib/kubelet/pods
       serviceAccountName: useroot
-      nodeSelector:
-        node-role.kubernetes.io/worker: ""
-        pbench_agent: "true"
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: node-role.kubernetes.io/worker
+                operator: Exists
+              - key: node-role.kubernetes.io/infra
+                operator: DoesNotExist
+              - key: pbench_agent
+                operator: In
+                values:
+                - "true"

--- a/workloads/tooling.yml
+++ b/workloads/tooling.yml
@@ -109,7 +109,7 @@
 
     - name: Label two worker nodes
       shell: |
-        oc get nodes -l node-role.kubernetes.io/worker= --no-headers | head -n 2 | awk '{print $1}' | xargs -I % oc label nodes % --overwrite pbench_agent=true
+        oc get nodes -l node-role.kubernetes.io/worker= --no-headers | grep -v infra | head -n 2 | awk '{print $1}' | xargs -I % oc label nodes % --overwrite pbench_agent=true
 
     - name: Create kubeconfig secret
       shell: |


### PR DESCRIPTION
On OSD, infra nodes are also labeled as worker nodes by a technical
limitation. This change will make it so that the scale testing will only
select worker nodes that are not also labeled as infra nodes. This
should be transparent for regular scale testing as the infra nodes are
not labeled this way, but should hopefully maintain parity with the
intended functionality on OSD.

Note: Working on testing.