### PR TITLE
Add support to the test workload to skip running on workload node

### DIFF
--- a/workloads/vars/test.yml
+++ b/workloads/vars/test.yml
@@ -13,6 +13,11 @@ orchestration_user: "{{ lookup('env', 'ORCHESTRATION_USER')|default('root', true
 # Container image in use
 workload_image: "{{ lookup('env', 'WORKLOAD_IMAGE')|default('quay.io/openshift-scale/scale-ci-workload', true) }}"
 
+# workload variables
+workload_job_node_selector: "{{ lookup('env', 'WORKLOAD_JOB_NODE_SELECTOR')|default(false, true)|bool }}"
+workload_job_taint: "{{ lookup('env', 'WORKLOAD_JOB_TAINT')|default(false, true)|bool }}"
+workload_job_privileged: "{{ lookup('env', 'WORKLOAD_JOB_PRIVILEGED')|default(true, true)|bool }}"
+
 # Kubeconfig for tooling container script
 kubeconfig_file: "{{ lookup('env', 'KUBECONFIG_FILE')|default('~/.kube/config', true) }}"
 


### PR DESCRIPTION
The test workload pod which basically just runs sleep infinity to allow
us to run benchmarks which are not automated tries to run on the dedicated
workload node created as part of the post-install ( day 2 operation ) by
default. This commit exposes the the workload node selector, taints and
running the pod in privileged/unpriveleged mode option to give the user
more flexibility to be able to run the workload even in the absence of
dedicated workload node.