### PR TITLE
Clear pbench remotes before configuring

### DIFF
--- a/workloads/files/workload-conformance-script-cm.yml
+++ b/workloads/files/workload-conformance-script-cm.yml
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for Conformance"
 
     workload_log "Running Conformance"

--- a/workloads/files/workload-http-script-cm.yml
+++ b/workloads/files/workload-http-script-cm.yml
@@ -11,6 +11,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +e
+      pbench-clear-tools
+      set -e
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -32,7 +37,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     # End pbench Configuration
 
     # Test Configuration

--- a/workloads/files/workload-prometheus-script-cm.yml
+++ b/workloads/files/workload-prometheus-script-cm.yml
@@ -14,6 +14,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eox pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -31,7 +36,6 @@ data:
         echo "infra" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for Prometheus scale"
 
     workload_log "Running Prometheus scale workload"

--- a/workloads/files/workload-scale-script-cm.yml
+++ b/workloads/files/workload-scale-script-cm.yml
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for Scale workload run"
 
     workload_log "Running scale workload"

--- a/workloads/files/workload-test-script-cm.yml
+++ b/workloads/files/workload-test-script-cm.yml
@@ -9,6 +9,9 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      pbench-clear-tools | exit 0
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -30,7 +33,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     # End pbench Configuration
 
     # Test Configuration

--- a/workloads/templates/workload-baseline-script-cm.yml.j2
+++ b/workloads/templates/workload-baseline-script-cm.yml.j2
@@ -11,6 +11,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -32,7 +37,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     echo "$(date -u) Done configuring pbench for Baseline worload run"
     # End pbench Configuration
 

--- a/workloads/templates/workload-deployments-per-ns-script-cm.yml.j2
+++ b/workloads/templates/workload-deployments-per-ns-script-cm.yml.j2
@@ -11,6 +11,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -32,7 +37,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     echo "$(date -u) Done configuring pbench for Deployments per ns cluster limits test"
     # End pbench Configuration
 

--- a/workloads/templates/workload-fio-script-cm.yml.j2
+++ b/workloads/templates/workload-fio-script-cm.yml.j2
@@ -13,6 +13,11 @@ data:
     echo "" > /var/lib/pbench-agent/tools-default/oc
     echo "workload" > /var/lib/pbench-agent/tools-default/label
     if [[ -v ENABLE_PBENCH_AGENTS ]]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "" > /var/lib/pbench-agent/tools-default/mpstat
@@ -37,7 +42,6 @@ data:
         echo "storage" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     echo "$(date -u) Done configuring pbench for FIO I/O scale test"
     # End pbench Configuration
     #

--- a/workloads/templates/workload-mastervertical-script-cm.yml.j2
+++ b/workloads/templates/workload-mastervertical-script-cm.yml.j2
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for MasterVertical"
 
     workload_log "Configuring MasterVertical test"

--- a/workloads/templates/workload-namespaces-per-cluster-script-cm.yml.j2
+++ b/workloads/templates/workload-namespaces-per-cluster-script-cm.yml.j2
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [[ -v ENABLE_PBENCH_AGENTS ]]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for Namespaces per cluster test"
 
     workload_log "Configuring Namespaces per cluster test"

--- a/workloads/templates/workload-network-script-cm.yml.j2
+++ b/workloads/templates/workload-network-script-cm.yml.j2
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     log "Done configuring pbench Network benchmarks"
     # End pbench Configuration
 

--- a/workloads/templates/workload-nodevertical-script-cm.yml.j2
+++ b/workloads/templates/workload-nodevertical-script-cm.yml.j2
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench NodeVertical"
 
     workload_log "Configuring NodeVertical test"

--- a/workloads/templates/workload-podvertical-script-cm.yml.j2
+++ b/workloads/templates/workload-podvertical-script-cm.yml.j2
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for PodVertical"
 
     workload_log "Configuring PodVertical test"

--- a/workloads/templates/workload-pvcscale-script-cm.yml.j2
+++ b/workloads/templates/workload-pvcscale-script-cm.yml.j2
@@ -11,6 +11,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [ "${ENABLE_PBENCH_AGENTS}" = true ]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -32,7 +37,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     echo "$(date -u) Done configuring pbench for PVC scale test"
     # End pbench Configuration
 

--- a/workloads/templates/workload-services-per-namespace-script-cm.yml.j2
+++ b/workloads/templates/workload-services-per-namespace-script-cm.yml.j2
@@ -12,6 +12,11 @@ data:
     mkdir -p /var/lib/pbench-agent/tools-default/
     echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> /etc/passwd
     if [[ -v ENABLE_PBENCH_AGENTS ]]; then
+      source /opt/pbench-agent/profile
+      # clear tools/remotes to make sure there are no invalid remotes
+      set +eo pipefail
+      pbench-clear-tools
+      set -eo pipefail
       echo "" > /var/lib/pbench-agent/tools-default/disk
       echo "" > /var/lib/pbench-agent/tools-default/iostat
       echo "workload" > /var/lib/pbench-agent/tools-default/label
@@ -33,7 +38,6 @@ data:
         echo "worker" > /var/lib/pbench-agent/tools-default/remote@$node
       done
     fi
-    source /opt/pbench-agent/profile
     workload_log "Done configuring pbench for services per namespace test"
 
     workload_log "Configuring services per namespace test"


### PR DESCRIPTION
This commit fixes the issue where there might be stale remotes
left from the previous benchmark runs which might no longer exist
because of operations like scale down. pbench-clear-tools is run to
clear them before configuring the remotes for each benchmark run.