### PR TITLE
client pod will land on workload node if it is present

### DIFF
--- a/workloads/files/workload-http-script-cm.yml
+++ b/workloads/files/workload-http-script-cm.yml
@@ -301,8 +301,15 @@ data:
       local oc_whoami=`oc whoami`
 
       test "$HTTP_TEST_LOAD_GENERATOR_NODES" || {
-        echo "Not (un)labelling nodes, load generator nodes unspecified."
-        return 0
+        echo "Load generator nodes unspecified."
+        if [ $HTTP_TEST_LOAD_GENERATORS -eq 1 ] ; then
+          HTTP_TEST_LOAD_GENERATOR_NODES=$(oc get nodes --no-headers | grep "workload" |  awk '{print $1}')
+          test "$HTTP_TEST_LOAD_GENERATOR_NODES" || {
+            return 0
+          }
+        else
+          return 0
+        fi
       }
 
       check_admin || {


### PR DESCRIPTION
It is not possible to specify workload node during pipeline runs as there is a fresh install every time.
This commit will make sure that client pod/load_generator will land on workload node. 