### PR TITLE
add ability to run scaleup without pbench tooling

### DIFF
--- a/workloads/scale.yml
+++ b/workloads/scale.yml
@@ -75,18 +75,16 @@
       delay: 1
       when: scale_ci_tooling_ns_exists.rc == 0
 
-    - name: Block for non-existing tooling namespace
-      block:
-        - name: Create tooling namespace
-          shell: |
-            oc create -f {{ansible_user_dir}}/scale-ci-tooling/scale-ci-tooling-ns.yml
-
-        - name: Create tooling service account
-          shell: |
-            oc create serviceaccount useroot -n scale-ci-tooling
-            oc adm policy add-scc-to-user privileged -z useroot -n scale-ci-tooling
-          when: enable_pbench_agents|bool
+    - name: Create tooling namespace
+      shell: |
+        oc create -f {{ansible_user_dir}}/scale-ci-tooling/scale-ci-tooling-ns.yml
       when: scale_ci_tooling_ns_exists.rc != 0
+
+    - name: Create tooling service account
+      shell: |
+        oc create serviceaccount useroot -n scale-ci-tooling
+        oc adm policy add-scc-to-user privileged -z useroot -n scale-ci-tooling
+      ignore_errors: true
 
     - name: Create/replace kubeconfig secret
       shell: |


### PR DESCRIPTION
Earlier the service account 'useroot' creation was dependent on running the tooling playbook (pbench).
This commit will help us avoid https://mastern-jenkins-csb-openshift-qe.cloud.paas.psi.redhat.com/job/ATS-SCALE-CI-SCALE/109/console

`  Error creating: pods "scale-ci-scale-" is forbidden: error looking up service account scale-ci-tooling/useroot: serviceaccount "useroot" not found`