### PR TITLE
Add a note about pbench deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Tool an OpenShift cluster and run OpenShift Performance and Scale Workloads.
 
+**NOTE**: The pbench integration in this repository is not being actively maintained/supported but can be used as is if it serves the need and works without any issues. All the workloads in the repository are being actively maintained/supported. It's recommended to use metrics captured by Prometheus to analyze the results.
+
 ## Documentation, Usage and Examples
 
 [See docs directory](docs/)


### PR DESCRIPTION
This commit adds a note about the pbench integration not being
actively maintained/supported in the Workloads repository. It can
still be used as is if it works without any issues. All the workloads
are being actively maintained/supported and it's recommended
to use Prometheus metrics to analyze the results.