### PR TITLE
Have HTTP Workload index run_id

### DIFF
--- a/workloads/files/workload-http-script-cm.yml
+++ b/workloads/files/workload-http-script-cm.yml
@@ -1475,10 +1475,11 @@ data:
     import string 
     import random
 
-    def _json_payload(uuid, test_type, test_name, routes, conn_per_targetroute, keepalive, tls_reuse, delay, runtime, requests_per_second, latency_95pctl, timestamp_newyork, num_workload_generators):
+    def _json_payload(uuid, test_type, test_name, routes, conn_per_targetroute, keepalive, tls_reuse, delay, runtime, requests_per_second, latency_95pctl, timestamp_newyork, num_workload_generators, run_id):
         processed = []
         processed.append({
             "uuid" : uuid,
+            "run_id": run_id,
             "test_type" : test_type,
             "test_name" : test_name,
             "routes" : routes,
@@ -1511,6 +1512,7 @@ data:
         keepalive = int(os.environ["keepalive"])
         tls_reuse = os.environ["tls_reuse"]
         delay = int(os.environ["delay"])
+        run_id = os.environ.get("RUN_ID", "test-run")
         runtime = int(os.environ["runtime"])
         requests_per_second = float(os.environ["requests_per_second"])
         latency_95pctl = float(os.environ["latency_95pctl"])
@@ -1518,7 +1520,7 @@ data:
         num_workload_generators = float(os.environ["HTTP_TEST_LOAD_GENERATORS"])
         timestamp_newyork = datetime.datetime.now()
         
-        documents = _json_payload(uuid, test_type, test_name, routes, conn_per_targetroute, keepalive, tls_reuse, delay, runtime, requests_per_second, latency_95pctl, timestamp_newyork, num_workload_generators)
+        documents = _json_payload(uuid, test_type, test_name, routes, conn_per_targetroute, keepalive, tls_reuse, delay, runtime, requests_per_second, latency_95pctl, timestamp_newyork, num_workload_generators, run_id)
         if len(documents) > 0:
             _index_result("router-test-results", server, port, documents)
 

--- a/workloads/templates/workload-env.yml.j2
+++ b/workloads/templates/workload-env.yml.j2
@@ -4,6 +4,7 @@ metadata:
   name: scale-ci-workload-{{workload_job}}-env
 data:
   ENABLE_PBENCH_AGENTS: "{{enable_pbench_agents|bool|lower}}"
+  RUN_ID: "{{run_id}}"
   PPROF_COLLECT: "{{ ((pprof_collect == None) | ternary(false, pprof_collect)) if pprof_collect is defined else false}}"
 {% if workload_job == "http" %}
 {% for v in http_env_vars %}

--- a/workloads/vars/baseline.yml
+++ b/workloads/vars/baseline.yml
@@ -32,6 +32,7 @@ pbench_server: "{{ lookup('env', 'PBENCH_SERVER')|default('', true) }}"
 # Other variables for workload tests
 scale_ci_results_token: "{{ lookup('env', 'SCALE_CI_RESULTS_TOKEN')|default('', true) }}"
 job_completion_poll_attempts: "{{ lookup('env', 'JOB_COMPLETION_POLL_ATTEMPTS')|default(360, true)|int }}"
+run_id: "{{ lookup('env', 'RUN_ID') | default('test-run', true) }}"
 
 # Idle workload specific parameters:
 baseline_test_prefix: "{{ lookup('env', 'BASELINE_TEST_PREFIX')|default('baseline', true) }}"

--- a/workloads/vars/http.yml
+++ b/workloads/vars/http.yml
@@ -25,7 +25,7 @@ pbench_server: "{{ lookup('env', 'PBENCH_SERVER')|default('', true) }}"
 # Other variables for workload tests
 scale_ci_results_token: "{{ lookup('env', 'SCALE_CI_RESULTS_TOKEN')|default('', true) }}"
 job_completion_poll_attempts: "{{ lookup('env', 'JOB_COMPLETION_POLL_ATTEMPTS')|default(1000, true)|int }}"
-
+run_id: "{{ lookup('env', 'RUN_ID') | default('test-run', true) }}"
 # HTTP workload specific parameters
 http_env_vars: [
   "ES_SERVER",


### PR DESCRIPTION
Allows run_id to be specified via environment variable `RUN_ID`